### PR TITLE
v0.0.3.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GreatPlainsBCGCalc
 Type: Package
 Title: Great Plains Macroinvertebrate and Fish BCGs Calculator
-Version: 0.0.2.9000
+Version: 0.0.3.9000
 Authors@R: person("Benjamin D.", "Block", , "Ben.Block@tetratech.com", role = c("aut", "cre"))
            person("Erik W.", "Leppo", email="Erik.Leppo@tetratech.com", role=c("aut","cre"))
 Maintainer: Ben Block <Ben.Block@tetratech.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,16 @@
 GreatPlainsBCGCalc-NEWS
 ================
 <Ben.Block@tetratech.com>
-2024-05-14 12:16:25.139745
+2024-05-30 14:09:10.394203
 
 <!-- NEWS.md is generated from NEWS.Rmd. Please edit that file -->
 
-    #> Last Update: 2024-05-14 12:16:25.158558
+    #> Last Update: 2024-05-30 14:09:10.423742
+
+# GreatPlainsBCGCalc 0.0.3.9000 (2024-05-30)
+
+- Add trim_ws parameter as TRUE to taxa_translate routine in Shiny app
+- Add metric calculation code for quant v. qual samples (IA and MO)
 
 # GreatPlainsBCGCalc 0.0.2.9000 (2024-05-14)
 

--- a/NEWS.rmd
+++ b/NEWS.rmd
@@ -21,6 +21,11 @@ knitr::opts_chunk$set(
 cat(paste0("Last Update: ",Sys.time()))
 ```
 
+# GreatPlainsBCGCalc 0.0.3.9000 (2024-05-30)
+
+* Add trim_ws parameter as TRUE to taxa_translate routine in Shiny app
+* Add metric calculation code for quant v. qual samples (IA and MO)
+
 # GreatPlainsBCGCalc 0.0.2.9000 (2024-05-14)
 
 * Bug models calculating correctly

--- a/inst/apps/GreatPlainsBCGCalc/global.R
+++ b/inst/apps/GreatPlainsBCGCalc/global.R
@@ -1,7 +1,7 @@
 # Shiny Global File
 
 # Version ----
-pkg_version <- "0.0.2.9000"
+pkg_version <- "0.0.3.9000"
 
 # Packages----
 library(BCGcalc)


### PR DESCRIPTION
* Add trim_ws parameter as TRUE to taxa_translate routine in Shiny app
* Add metric calculation code for quant v. qual samples (IA and MO)

Adds functionality for IA and MO to run metrics for quant and qual samples.  Reports as single data frame similar to other all quant samples (e.g., KS).  IA needs the column BUGGEAR and kicks out with a pop up if missing.